### PR TITLE
Allow sending multiple commands at once.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ Usage
                             foractivities otherwise only current activity will be
                             shown.
         send_command        Send a simple command.
+        send_commands       Send a series of simple commands separated by spaces.
         change_channel      Change the channel
 
     optional arguments:


### PR DESCRIPTION
Adds the possibility to send multiple harmony commands (separated by spaces) using a single terminal command.

It's useful for passing different commands at once or switching to a single channel with a series of digits.

Examples:

Switch on, volume up twice and switch to channel 6.
```
$ aioharmony --harmony_ip 'XXX' send_commands --device_id 'XXX' --commands 'PowerOn VolumeUp VolumeUp 6'
```

Switch to channel 156.
```
$ aioharmony --harmony_ip 'XXX' send_commands --device_id 'XXX' --commands '1 5 6'
```

`repeat` is not supported as I thought it would be an overkill in this case.