### PR TITLE
fix: websocket connection drops on flaky WiFi networks

### DIFF
--- a/src/aioharmony/hubconnector_websocket.py
+++ b/src/aioharmony/hubconnector_websocket.py
@@ -33,6 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 # TODO: Clean up code styling
 
 _WS_TIMEOUT = ClientWSTimeout(ws_receive=None, ws_close=DEFAULT_TIMEOUT)
+_WS_HEARTBEAT = 30  # Send ping every 30s, expect pong within 15s
 
 
 # pylint: disable=too-many-instance-attributes
@@ -155,7 +156,7 @@ class HubConnector:
                 self._websocket = await self._session.ws_connect(
                     f"ws://{self._ip_address}:{DEFAULT_HUB_PORT}/?domain={self._domain}&hubId={self._remote_id}",
                     timeout=_WS_TIMEOUT,  # close timeout
-                    heartbeat=10,
+                    heartbeat=_WS_HEARTBEAT,
                 )
             except (
                 aiohttp.ServerTimeoutError,


### PR DESCRIPTION
## Summary
Increases the websocket heartbeat interval from 10 to 30 seconds to better handle network latency and temporary WiFi connectivity issues with Harmony Hubs.

## Problem
- Harmony Hub integration fails with "No PONG received after 5.0 seconds" errors
- With heartbeat=10, aiohttp expects PONG responses within 5 seconds (heartbeat/2)
- Flaky WiFi or busy hubs may not respond within this tight 5-second window

## Solution
- Added `_WS_HEARTBEAT = 30` constant, giving hubs 15 seconds to respond to pings
- More tolerant of network congestion and temporary connectivity issues

Fixes: https://github.com/home-assistant/core/issues/147701