### PR TITLE
fix: trigger websocket reconnect on listener error paths

### DIFF
--- a/src/aioharmony/hubconnector_websocket.py
+++ b/src/aioharmony/hubconnector_websocket.py
@@ -33,6 +33,13 @@ _LOGGER = logging.getLogger(__name__)
 
 _WS_TIMEOUT = ClientWSTimeout(ws_receive=None, ws_close=DEFAULT_TIMEOUT)
 _WS_HEARTBEAT = 30  # Send ping every 30s, expect pong within 15s
+_WS_CLOSE_TYPES = frozenset(
+    {
+        aiohttp.WSMsgType.CLOSED,
+        aiohttp.WSMsgType.CLOSE,
+        aiohttp.WSMsgType.CLOSING,
+    }
+)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -373,11 +380,7 @@ class HubConnector:
                     "%s: Response payload: %s", self._ip_address, response.data
                 )
 
-                if response.type in (
-                    aiohttp.WSMsgType.CLOSED,
-                    aiohttp.WSMsgType.CLOSE,
-                    aiohttp.WSMsgType.CLOSING,
-                ):
+                if response.type in _WS_CLOSE_TYPES:
                     close_code = (
                         ""
                         if response.data is None

--- a/src/aioharmony/hubconnector_websocket.py
+++ b/src/aioharmony/hubconnector_websocket.py
@@ -360,14 +360,24 @@ class HubConnector:
                 try:
                     response = await websocket.receive()
                 except aiohttp.ClientError:
-                    _LOGGER.exception("%s: Exception during receive", self._ip_address)
+                    # Heartbeat timeout / connection reset surfaces here.
+                    # Must trigger reconnect, otherwise the integration stays offline.
+                    _LOGGER.warning(
+                        "%s: Exception during receive, will reconnect",
+                        self._ip_address,
+                    )
+                    have_connection = False
                     break
 
                 _LOGGER.debug(
                     "%s: Response payload: %s", self._ip_address, response.data
                 )
 
-                if response.type is aiohttp.WSMsgType.CLOSED:
+                if response.type in (
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSING,
+                ):
                     close_code = (
                         ""
                         if response.data is None
@@ -381,10 +391,13 @@ class HubConnector:
                     break
 
                 if response.type is aiohttp.WSMsgType.ERROR:
-                    _LOGGER.error(
-                        "%s: Response error: %s", self._ip_address, response.data
+                    _LOGGER.warning(
+                        "%s: Response error, will reconnect: %s",
+                        self._ip_address,
+                        response.data,
                     )
-                    continue
+                    have_connection = False
+                    break
 
                 if response.type is not aiohttp.WSMsgType.TEXT:
                     continue
@@ -410,7 +423,11 @@ class HubConnector:
             # Need to catch everything here to prevent an issue in a
             # callback from ever causing the handler to exit.
             except Exception:
-                _LOGGER.exception("%s: Exception in listener", self._ip_address)
+                _LOGGER.exception(
+                    "%s: Exception in listener, will reconnect", self._ip_address
+                )
+                have_connection = False
+                break
 
         self._listener_task = None
         _LOGGER.debug("%s: Listener stopped.", self._ip_address)

--- a/tests/test_hubconnector_websocket.py
+++ b/tests/test_hubconnector_websocket.py
@@ -1,0 +1,219 @@
+"""Tests for the websocket listener reconnect paths."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from aioharmony.const import ConnectorCallbackType
+from aioharmony.hubconnector_websocket import HubConnector
+
+
+class FakeWebSocket:
+    """Minimal websocket stub for driving HubConnector._listener.
+
+    `messages` is a deque whose entries are either:
+      - an aiohttp.WSMessage-like MagicMock for receive() to return, or
+      - an Exception class/instance for receive() to raise.
+
+    Once exhausted, receive() returns a CLOSED message so the loop terminates
+    deterministically if the test forgot to set the websocket as closed.
+    """
+
+    def __init__(self, messages: list[Any]) -> None:
+        self._messages: deque[Any] = deque(messages)
+        self.closed = False
+
+    async def receive(self) -> Any:
+        if not self._messages:
+            self.closed = True
+            return _make_message(aiohttp.WSMsgType.CLOSED, data=1000)
+        item = self._messages.popleft()
+        if isinstance(item, BaseException) or (
+            isinstance(item, type) and issubclass(item, BaseException)
+        ):
+            self.closed = True
+            raise item if isinstance(item, BaseException) else item("boom")
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _make_message(msg_type: aiohttp.WSMsgType, data: Any = None) -> MagicMock:
+    msg = MagicMock()
+    msg.type = msg_type
+    msg.data = data
+    return msg
+
+
+def _make_connector() -> HubConnector:
+    queue: asyncio.Queue = asyncio.Queue()
+    connector = HubConnector(
+        ip_address="10.0.0.1",
+        response_queue=queue,
+        callbacks=ConnectorCallbackType(connect=None, disconnect=None),
+    )
+    connector._connected = True  # noqa: SLF001
+    connector._remote_id = "abc"  # noqa: SLF001
+    return connector
+
+
+async def _run_listener_once(
+    connector: HubConnector, fake_ws: FakeWebSocket
+) -> AsyncMock:
+    """Run _listener and capture a single reconnect attempt.
+
+    Patches hub_connect to a synchronous AsyncMock returning True so that
+    _reconnect's retry loop exits after one call. Returns the mock so callers
+    can assert on call counts.
+    """
+    hub_connect = AsyncMock(return_value=True)
+    connector.hub_connect = hub_connect  # type: ignore[method-assign]
+    # _reconnect closes the session if it is non-None; bypass that work.
+    connector.async_close_session = AsyncMock()  # type: ignore[method-assign]
+
+    connector._websocket = fake_ws  # type: ignore[assignment]  # noqa: SLF001
+    await connector._listener(fake_ws)  # noqa: SLF001
+    return hub_connect
+
+
+@pytest.mark.asyncio
+async def test_listener_reconnects_on_client_error_during_receive() -> None:
+    """A ClientError from receive() must trigger reconnect.
+
+    Regression: previously this path broke out of the loop without setting
+    have_connection=False, so _reconnect was never called and the integration
+    stayed offline.
+    """
+    fake_ws = FakeWebSocket([aiohttp.ClientError])
+    connector = _make_connector()
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_reconnects_on_ws_error_message() -> None:
+    """A WSMsgType.ERROR message must trigger reconnect, not spin."""
+    fake_ws = FakeWebSocket(
+        [_make_message(aiohttp.WSMsgType.ERROR, data=RuntimeError("bad"))]
+    )
+    connector = _make_connector()
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_reconnects_on_ws_close_message() -> None:
+    """A WSMsgType.CLOSE handshake must trigger reconnect immediately."""
+    fake_ws = FakeWebSocket([_make_message(aiohttp.WSMsgType.CLOSE, data=1000)])
+    connector = _make_connector()
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_reconnects_on_ws_closing_message() -> None:
+    """A WSMsgType.CLOSING handshake must trigger reconnect immediately."""
+    fake_ws = FakeWebSocket([_make_message(aiohttp.WSMsgType.CLOSING, data=1000)])
+    connector = _make_connector()
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_reconnects_on_ws_closed_message() -> None:
+    """A WSMsgType.CLOSED message must trigger reconnect (existing behavior)."""
+    fake_ws = FakeWebSocket([_make_message(aiohttp.WSMsgType.CLOSED, data=1000)])
+    connector = _make_connector()
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_reconnects_on_unexpected_exception() -> None:
+    """An unexpected exception inside the loop must trigger reconnect.
+
+    Regression: previously the broad `except Exception` only logged, so the
+    listener could spin forever on a recurring error.
+    """
+
+    class BoomMessage:
+        """A message-like object whose attribute access raises."""
+
+        @property
+        def type(self) -> aiohttp.WSMsgType:
+            raise RuntimeError("boom")
+
+        @property
+        def data(self) -> Any:
+            return None
+
+    fake_ws = FakeWebSocket([BoomMessage()])
+    connector = _make_connector()
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_does_not_reconnect_when_disconnected() -> None:
+    """If the user called disconnect, reconnect must not fire."""
+    fake_ws = FakeWebSocket([aiohttp.ClientError])
+    connector = _make_connector()
+    connector._connected = False  # noqa: SLF001  # simulate explicit disconnect
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_listener_passes_text_message_to_queue() -> None:
+    """Sanity check: TEXT messages still flow to the response queue."""
+    text_msg = _make_message(aiohttp.WSMsgType.TEXT)
+    text_msg.json.return_value = {"hello": "world"}
+    fake_ws = FakeWebSocket(
+        [text_msg, _make_message(aiohttp.WSMsgType.CLOSED, data=1000)]
+    )
+    connector = _make_connector()
+
+    await _run_listener_once(connector, fake_ws)
+
+    assert connector._response_queue.get_nowait() == {"hello": "world"}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_listener_does_not_reconnect_when_auto_reconnect_disabled() -> None:
+    """auto_reconnect=False must suppress reconnect even on ClientError."""
+    queue: asyncio.Queue = asyncio.Queue()
+    connector = HubConnector(
+        ip_address="10.0.0.1",
+        response_queue=queue,
+        callbacks=ConnectorCallbackType(connect=None, disconnect=None),
+        auto_reconnect=False,
+    )
+    connector._connected = True  # noqa: SLF001
+    connector._remote_id = "abc"  # noqa: SLF001
+
+    fake_ws = FakeWebSocket([aiohttp.ClientError])
+
+    hub_connect = await _run_listener_once(connector, fake_ws)
+
+    assert hub_connect.await_count == 0


### PR DESCRIPTION
## Summary
The websocket listener exited without triggering reconnect on three paths; ClientError from receive (the heartbeat timeout path), WSMsgType.ERROR, and unexpected exceptions inside the loop body. Each now sets have_connection=False and breaks so _reconnect runs. Also handles WSMsgType.CLOSE and CLOSING explicitly so the reconnect fires immediately instead of waiting for a CLOSED that may never arrive.

## Test plan
Added tests/test_hubconnector_websocket.py covering each path that should fire reconnect; ClientError, ERROR, CLOSE, CLOSING, CLOSED, and unexpected exception in the loop, plus negatives for explicit disconnect and auto_reconnect=False. All 9 pass via uv run pytest.