### PR TITLE
ci: add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Home Automation',


### PR DESCRIPTION
## Summary
Adds Python 3.14 to the CI matrix and to the trove classifier list. No source changes; nothing in src uses APIs removed or deprecated in 3.14.

## Test plan
CI runs the existing pytest suite on 3.14 alongside 3.10 through 3.13; passing on all five entries is the verification.