### PR TITLE
fix: protocol type alias raises TypeError at import

### DIFF
--- a/src/aioharmony/const.py
+++ b/src/aioharmony/const.py
@@ -4,7 +4,7 @@ Constants used throughout the modules
 
 import asyncio
 from collections.abc import Callable
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 #
 # DEFAULT values
@@ -18,7 +18,7 @@ DEFAULT_HARMONY_MIME = "vnd.logitech.harmony/vnd.logitech.harmony.engine"
 WEBSOCKETS = "WEBSOCKETS"
 XMPP = "XMPP"
 
-PROTOCOL = WEBSOCKETS | XMPP
+PROTOCOL = Literal["WEBSOCKETS", "XMPP"]
 
 #
 # The HUB commands that can be send


### PR DESCRIPTION
## Summary
The typing modernization sweep in #97 rewrote PROTOCOL = Union[WEBSOCKETS, XMPP] as PROTOCOL = WEBSOCKETS | XMPP, but WEBSOCKETS and XMPP are str values not types, so Python evaluates "WEBSOCKETS" | "XMPP" at runtime and raises TypeError. Importing aioharmony.const blows up; the package is currently uninstallable in practice. Replaces it with Literal["WEBSOCKETS", "XMPP"], which is what the alias was always meant to express.

## Test plan
Local import smoke check (from aioharmony.const import PROTOCOL) and the existing pytest suite pass with this branch.