### PR TITLE
fix: stop reconnect retry loop on concurrent disconnect

### DIFF
--- a/src/aioharmony/hubconnector_websocket.py
+++ b/src/aioharmony/hubconnector_websocket.py
@@ -282,13 +282,21 @@ class HubConnector:
         self._websocket = None
 
         is_reconnect = False
-        self._connected = False
         sleep_time = 1
-        await asyncio.sleep(sleep_time)
-        while not await self.hub_connect(is_reconnect=is_reconnect):
+        while True:
             await asyncio.sleep(sleep_time)
-            sleep_time = sleep_time * 2
-            sleep_time = min(sleep_time, 30)
+            # Re-check between attempts so a concurrent hub_disconnect() (or
+            # auto_reconnect being turned off) actually stops the retry loop;
+            # _connected reflects "caller wants us connected".
+            if not self._connected or not self._auto_reconnect:
+                _LOGGER.debug(
+                    "%s: Disconnect requested during reconnect, stopping",
+                    self._ip_address,
+                )
+                return
+            if await self.hub_connect(is_reconnect=is_reconnect):
+                return
+            sleep_time = min(sleep_time * 2, 30)
             is_reconnect = True
 
     async def hub_send(

--- a/src/aioharmony/hubconnector_websocket.py
+++ b/src/aioharmony/hubconnector_websocket.py
@@ -288,9 +288,15 @@ class HubConnector:
             # Re-check between attempts so a concurrent hub_disconnect() (or
             # auto_reconnect being turned off) actually stops the retry loop;
             # _connected reflects "caller wants us connected".
-            if not self._connected or not self._auto_reconnect:
+            if not self._connected:
                 _LOGGER.debug(
                     "%s: Disconnect requested during reconnect, stopping",
+                    self._ip_address,
+                )
+                return
+            if not self._auto_reconnect:
+                _LOGGER.debug(
+                    "%s: Auto-reconnect disabled during reconnect, stopping",
                     self._ip_address,
                 )
                 return

--- a/tests/test_hubconnector_websocket.py
+++ b/tests/test_hubconnector_websocket.py
@@ -219,9 +219,14 @@ async def test_listener_does_not_reconnect_when_auto_reconnect_disabled() -> Non
     assert hub_connect.await_count == 0
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def fast_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace asyncio.sleep inside the module so retry-loop tests are fast."""
+    """Replace asyncio.sleep inside the module so retry-loop tests are fast.
+
+    Applied to every test in this module; the listener tests also reach
+    _reconnect() via the listener exit path and would otherwise pay the 1s
+    initial backoff each.
+    """
 
     async def _no_sleep(_delay: float) -> None:
         return None
@@ -230,9 +235,7 @@ def fast_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reconnect_stops_when_disconnect_called_during_retry(
-    fast_sleep: None,
-) -> None:
+async def test_reconnect_stops_when_disconnect_called_during_retry() -> None:
     """A concurrent hub_disconnect() must end the retry loop.
 
     Regression for issue #95: previously _reconnect set self._connected = False
@@ -258,9 +261,7 @@ async def test_reconnect_stops_when_disconnect_called_during_retry(
 
 
 @pytest.mark.asyncio
-async def test_reconnect_stops_when_auto_reconnect_disabled_during_retry(
-    fast_sleep: None,
-) -> None:
+async def test_reconnect_stops_when_auto_reconnect_disabled_during_retry() -> None:
     """Flipping auto_reconnect off during retries must also stop the loop."""
     connector = _make_connector()
     connector.async_close_session = AsyncMock()  # type: ignore[method-assign]
@@ -278,7 +279,7 @@ async def test_reconnect_stops_when_auto_reconnect_disabled_during_retry(
 
 
 @pytest.mark.asyncio
-async def test_reconnect_retries_until_success(fast_sleep: None) -> None:
+async def test_reconnect_retries_until_success() -> None:
     """The retry loop keeps trying with is_reconnect=True after the first miss."""
     connector = _make_connector()
     connector.async_close_session = AsyncMock()  # type: ignore[method-assign]
@@ -297,9 +298,7 @@ async def test_reconnect_retries_until_success(fast_sleep: None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reconnect_does_not_clobber_connected_flag(
-    fast_sleep: None,
-) -> None:
+async def test_reconnect_does_not_clobber_connected_flag() -> None:
     """_reconnect must leave self._connected alone.
 
     Regression for issue #95: _reconnect used to set self._connected = False

--- a/tests/test_hubconnector_websocket.py
+++ b/tests/test_hubconnector_websocket.py
@@ -217,3 +217,101 @@ async def test_listener_does_not_reconnect_when_auto_reconnect_disabled() -> Non
     hub_connect = await _run_listener_once(connector, fake_ws)
 
     assert hub_connect.await_count == 0
+
+
+@pytest.fixture
+def fast_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace asyncio.sleep inside the module so retry-loop tests are fast."""
+
+    async def _no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("aioharmony.hubconnector_websocket.asyncio.sleep", _no_sleep)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_stops_when_disconnect_called_during_retry(
+    fast_sleep: None,
+) -> None:
+    """A concurrent hub_disconnect() must end the retry loop.
+
+    Regression for issue #95: previously _reconnect set self._connected = False
+    before its retry loop and never re-checked it, so a hub_disconnect() that
+    arrived mid-retry could not stop a subsequent reconnect attempt.
+    """
+    connector = _make_connector()
+    connector.async_close_session = AsyncMock()  # type: ignore[method-assign]
+
+    async def fail_then_disconnect(is_reconnect: bool = False) -> bool:
+        # Simulate hub_disconnect() running between retries.
+        connector._connected = False  # noqa: SLF001
+        return False
+
+    hub_connect = AsyncMock(side_effect=fail_then_disconnect)
+    connector.hub_connect = hub_connect  # type: ignore[method-assign]
+
+    await connector._reconnect()  # noqa: SLF001
+
+    # First attempt runs once, then the loop checks _connected and bails;
+    # without the fix it would keep retrying forever.
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reconnect_stops_when_auto_reconnect_disabled_during_retry(
+    fast_sleep: None,
+) -> None:
+    """Flipping auto_reconnect off during retries must also stop the loop."""
+    connector = _make_connector()
+    connector.async_close_session = AsyncMock()  # type: ignore[method-assign]
+
+    async def fail_then_disable(is_reconnect: bool = False) -> bool:
+        connector._auto_reconnect = False  # noqa: SLF001
+        return False
+
+    hub_connect = AsyncMock(side_effect=fail_then_disable)
+    connector.hub_connect = hub_connect  # type: ignore[method-assign]
+
+    await connector._reconnect()  # noqa: SLF001
+
+    assert hub_connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reconnect_retries_until_success(fast_sleep: None) -> None:
+    """The retry loop keeps trying with is_reconnect=True after the first miss."""
+    connector = _make_connector()
+    connector.async_close_session = AsyncMock()  # type: ignore[method-assign]
+
+    hub_connect = AsyncMock(side_effect=[False, False, True])
+    connector.hub_connect = hub_connect  # type: ignore[method-assign]
+
+    await connector._reconnect()  # noqa: SLF001
+
+    assert hub_connect.await_count == 3
+    # First call is the initial attempt; subsequent calls flag is_reconnect.
+    first_call_kwargs = hub_connect.await_args_list[0].kwargs
+    later_call_kwargs = hub_connect.await_args_list[-1].kwargs
+    assert first_call_kwargs.get("is_reconnect") is False
+    assert later_call_kwargs.get("is_reconnect") is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_does_not_clobber_connected_flag(
+    fast_sleep: None,
+) -> None:
+    """_reconnect must leave self._connected alone.
+
+    Regression for issue #95: _reconnect used to set self._connected = False
+    before the retry loop, conflating "currently connected" with "caller
+    wants us connected" and defeating any later mid-retry disconnect check.
+    """
+    connector = _make_connector()
+    connector.async_close_session = AsyncMock()  # type: ignore[method-assign]
+
+    hub_connect = AsyncMock(return_value=True)
+    connector.hub_connect = hub_connect  # type: ignore[method-assign]
+
+    await connector._reconnect()  # noqa: SLF001
+
+    assert connector._connected is True  # noqa: SLF001


### PR DESCRIPTION
## Summary
Closes #95. _reconnect() used to set self._connected = False before its retry loop and never re-read it, so a hub_disconnect() arriving while the loop was sleeping could not stop the next attempt; a fresh websocket and listener would come back up after the caller asked to stop. The retry loop now re-checks _connected and _auto_reconnect between attempts, and the spurious assignment that masked the check is removed.

## Test plan
Four new tests in tests/test_hubconnector_websocket.py cover; disconnect during retry, auto_reconnect flipped off during retry, successful retry after failures (asserting is_reconnect flips on follow-up attempts), and that _reconnect leaves _connected alone. asyncio.sleep is monkey-patched in the module so the tests run instantly. All 13 tests pass via uv run pytest.

Closes #95