### PR TITLE
docs: add codecov badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 aioharmony
 ==========
 
+.. image:: https://codecov.io/gh/Harmony-Libs/aioharmony/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/Harmony-Libs/aioharmony
+   :alt: Codecov
+
 Python library for programmatically using a Logitech Harmony Link or Ultimate Hub.
 
 This library originated from `iandday/pyharmony <https://github.com/iandday/pyharmony>`__ which was a fork


### PR DESCRIPTION
## Summary

Adds a Codecov badge to the top of `README.rst`, linking to the existing Codecov project for this repo. Coverage is already uploaded from every cell of the `test` matrix via the `codecov/codecov-action@v6` step in `ci.yml`, so the badge will render with real data immediately.

## Test plan

- [x] RST `.. image::` block renders on GitHub's RST preview.
- [x] Badge URL (`https://codecov.io/gh/Harmony-Libs/aioharmony/branch/main/graph/badge.svg`) and target link follow the standard Codecov format and match this repo's slug.
